### PR TITLE
Fixed error handling in mn_decode()

### DIFF
--- a/mnemonic.c
+++ b/mnemonic.c
@@ -447,14 +447,15 @@ mn_decode (char *src, void *dest, int destsize)
 {
   mn_index index;
   int offset = 0;
+  int status;
 
   while ((index = mn_next_word_index (&src)) != 0)
     {
       (void) mn_decode_word_index (index, dest, destsize, &offset);
     }
-  if (index == 0 && *src != 0)
+  if (*src != 0)
     return MN_EWORD;
-  int status = mn_decode_word_index (MN_EOF, dest, destsize, &offset);
+  status = mn_decode_word_index (MN_EOF, dest, destsize, &offset);
   if (status < 0)
     return status;
   return offset;

--- a/mnemonic.c
+++ b/mnemonic.c
@@ -450,10 +450,12 @@ mn_decode (char *src, void *dest, int destsize)
 
   while ((index = mn_next_word_index (&src)) != 0)
     {
-      if (index == 0 && *src != 0)
-	return MN_EWORD;
       (void) mn_decode_word_index (index, dest, destsize, &offset);
     }
-  (void) mn_decode_word_index (MN_EOF, dest, destsize, &offset);
+  if (index == 0 && *src != 0)
+    return MN_EWORD;
+  int status = mn_decode_word_index (MN_EOF, dest, destsize, &offset);
+  if (status < 0)
+    return status;
   return offset;
 }


### PR DESCRIPTION
Fixed two bugs that kept mn_decode from reporting any errors:

1. The error check for `mn_next_word_index` was inside the loop, not outside, so it never triggered.
2. There was no check of the return value of the last `mn_decode_word_index` call, so no decoding errors were detected.