### PR TITLE
Created a github action to build and release it

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -3,7 +3,7 @@ name: releaser
 on:
     push:
         tags:
-            - 'v*.*.*'
+            - '*.*.*'
 
 jobs:
     ubuntubuild:

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -1,0 +1,26 @@
+name: releaser
+
+on:
+    push:
+        tags:
+            - 'v*.*.*'
+
+jobs:
+    ubuntubuild:
+        runs-on: ubuntu-latest
+        steps:
+            -   name: Checkout
+                uses: actions/checkout@v2
+                with:
+                    fetch-depth: 0
+            -   name: Build
+                run: |
+                  sudo apt-get install -y build-essential gcc mingw-w64-tools zip gzip tar g++-mingw-w64-x86-64
+                  make
+                  tar czf linux-amd64.tar.gz mnencode mndecode
+            - name: Upload release binaries
+              uses: alexellis/upload-assets@0.4.0
+              env:
+                GITHUB_TOKEN: ${{ github.token }}
+              with:
+                asset_paths: '["linux-amd64.tar.gz"]'


### PR DESCRIPTION
It could easily be expanded to do windows, mac and other architectures but this is minimal to what I needed.

To release create a tag beginning with a v that looks something like a semantic version. You can do that in the github UI too: https://github.com/singpolyma/mnemonicode/releases

You will also have to change the workflow permissions to allow it to upload the artifacts to the releases:
![image](https://user-images.githubusercontent.com/111667/218590603-ae6076c8-0cc3-4307-9ca2-752beba6223e.png)

Once done it will look something like this:
https://github.com/arran4/mnemonicode/releases/tag/v0.1.0
